### PR TITLE
changes to support subclassing of package

### DIFF
--- a/lib/Data/Money.pm
+++ b/lib/Data/Money.pm
@@ -1,6 +1,6 @@
 package Data::Money;
 
-$Data::Money::VERSION   = '0.11';
+$Data::Money::VERSION   = '0.12';
 $Data::Money::AUTHORITY = 'cpan:GPHAT';
 
 =head1 NAME
@@ -9,7 +9,7 @@ Data::Money - Money/currency with formatting and overloading.
 
 =head1 VERSION
 
-Version 0.11
+Version 0.12
 
 =cut
 
@@ -210,7 +210,7 @@ sub clone {
 
     $param{code}   = $self->code;
     $param{format} = $self->format;
-    return Data::Money->new( \%param );
+    return $self->new( \%param );
 }
 
 =head2 as_float()
@@ -283,7 +283,7 @@ sub add {
     my $self = shift;
     my $num  = shift || 0;
 
-    if (ref($num) eq 'Data::Money') {
+    if (ref($num) eq ref($self)) {
         Data::Money::BaseException::MismatchCurrencyType->throw
             if ($self->code ne $num->code);
 
@@ -304,7 +304,7 @@ modify the existing object.
 sub add_in_place {
     my ($self, $num) = @_;
 
-    if (ref($num) eq 'Data::Money') {
+    if (ref($num) eq ref($self)) {
         Data::Money::BaseException::MismatchCurrencyType->throw
             if ($self->code ne $num->code);
 
@@ -360,7 +360,7 @@ sub subtract {
     my $self = shift;
     my $num  = shift || 0;
 
-    if (ref($num) eq 'Data::Money') {
+    if (ref($num) eq ref($self)) {
         Data::Money::BaseException::MismatchCurrencyType->throw
             if ($self->code ne $num->code);
 
@@ -381,7 +381,7 @@ modify the existing object.
 sub subtract_in_place {
     my ($self, $num) = @_;
 
-    if (ref($num) eq 'Data::Money') {
+    if (ref($num) eq ref($self)) {
         Data::Money::BaseException::MismatchCurrencyType->throw
             if ($self->code ne $num->code);
 
@@ -404,7 +404,7 @@ B<does not> modify the existing object.
 sub multiply {
     my ($self, $num) = @_;
 
-    if (ref($num) eq 'Data::Money') {
+    if (ref($num) eq ref($self)) {
         Data::Money::BaseException::MismatchCurrencyType->throw
             if ($self->code ne $num->code);
 
@@ -425,7 +425,7 @@ the existing object.
 sub multiply_in_place {
     my ($self, $num) = @_;
 
-    if (ref($num) eq 'Data::Money') {
+    if (ref($num) eq ref($self)) {
         Data::Money::BaseException::MismatchCurrencyType->throw
             if ($self->code ne $num->code);
 
@@ -448,7 +448,7 @@ B<does not> modify the existing object.
 sub divide {
     my ($self, $num) = @_;
 
-    if (ref($num) eq 'Data::Money') {
+    if (ref($num) eq ref($self)) {
         Data::Money::BaseException::MismatchCurrencyType->throw
             if ($self->code ne $num->code);
 
@@ -472,7 +472,7 @@ sub divide_in_place {
     my ($self, $num) = @_;
 
     my $val;
-    if (ref($num) eq 'Data::Money') {
+    if (ref($num) eq ref($self)) {
         Data::Money::BaseException::MismatchCurrencyType->throw
             if ($self->code ne $num->code);
 
@@ -496,7 +496,7 @@ object with the value of the remainder.
 sub modulo {
     my ($self, $num) = @_;
 
-    if (ref($num) eq 'Data::Money') {
+    if (ref($num) eq ref($self)) {
         Data::Money::BaseException::MismatchCurrencyType->throw
             if ($self->code ne $num->code);
 
@@ -521,7 +521,7 @@ sub three_way_compare {
     my $num  = shift || 0;
 
     my $other;
-    if (ref($num) eq 'Data::Money') {
+    if (ref($num) eq ref($self)) {
         $other = $num;
     } else {
         # we clone here to ensure that if we're comparing a number to

--- a/t/subclass.t
+++ b/t/subclass.t
@@ -33,8 +33,8 @@ use Data::Dump qw/dump/;
 };
 
 {
-    my $gbp = Data::Money->new(code => 'GBP', value => 1);
-    my $cad = Data::Money->new(code => 'CAD', value => 1);
+    my $gbp = Data::Money::Too->new(code => 'GBP', value => 1);
+    my $cad = Data::Money::Too->new(code => 'CAD', value => 1);
 
     eval { my $result = $gbp + $cad; };
     ok($@ =~ /unable to perform arithmetic on different currency types/, 'code comparison caught for subclassed money types');

--- a/t/subclass.t
+++ b/t/subclass.t
@@ -1,0 +1,43 @@
+use Test::More;
+use strict;
+use warnings;
+use Encode;
+
+use Test::utf8;
+use Test::Exception;
+
+use Data::Money;
+use feature ':5.10';
+use Data::Dump qw/dump/;
+
+## subclass Data::Money
+{
+    package Data::Money::Too;
+    
+    use Moo;
+    extends 'Data::Money';
+    
+}
+
+
+## test subclass
+{
+    my $m1 = Data::Money::Too->new(value => 1);
+    cmp_ok(ref $m1, 'eq', 'Data::Money::Too', 'subclass new');
+
+    my $m2 = $m1 + 2;
+    cmp_ok(ref $m2, 'eq', 'Data::Money::Too', 'add num');
+
+    my $m3 = $m2 - $m1;
+    cmp_ok(ref $m3, 'eq', 'Data::Money::Too', 'subtract Money');
+};
+
+{
+    my $gbp = Data::Money->new(code => 'GBP', value => 1);
+    my $cad = Data::Money->new(code => 'CAD', value => 1);
+
+    eval { my $result = $gbp + $cad; };
+    ok($@ =~ /unable to perform arithmetic on different currency types/, 'code comparison caught for subclassed money types');
+};
+
+done_testing;


### PR DESCRIPTION
I've been using Data::Money for some time now. Nice work!

I have had to subclass and lightly wrap this package to support various serialization and coercion tasks.

Your recent changes broke my attribute constraints and coercions so I have proposed minor changes to the package to make it more friendly to subclassing.

I've changed the clone method and ref type comparisons from Data::Money to ref($self). There is also a subclass.t added to the project.

Would you consider adding these changes to your project?
